### PR TITLE
Add regression test database (30M accounts, 3.6GB)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+regression-data/*.bin filter=lfs diff=lfs merge=lfs -text
+regression-data/*.part* filter=lfs diff=lfs merge=lfs -text

--- a/regression-data/README.md
+++ b/regression-data/README.md
@@ -1,0 +1,86 @@
+# Plinko Regression Test Database
+
+A smaller Ethereum state snapshot for fast regression testing and development.
+
+## Dataset Summary
+
+| Metric | Value |
+|--------|-------|
+| Source Block | #23,889,314 (Dec 5, 2025) |
+| Accounts | 30,000,000 |
+| Storage Slots | 30,000,000 |
+| Total Entries (N) | 120,000,000 |
+| Database Size | 3.6 GB |
+
+## Files
+
+| File | Size | Description |
+|------|------|-------------|
+| `database.bin.partaa` | 1.9 GB | Flat array of 32-byte words (part 1) |
+| `database.bin.partab` | 1.7 GB | Flat array of 32-byte words (part 2) |
+| `account-mapping.bin` | 687 MB | Address → index lookup |
+| `storage-mapping.bin` | 1.6 GB | (Address, Slot) → index lookup |
+| `metadata.json` | 147 B | Extraction metadata |
+
+### Reassembling database.bin
+
+```bash
+cat database.bin.part* > database.bin
+```
+
+## Extraction Command
+
+```bash
+/mnt/mainnet/plinko/target/release/plinko-extractor \
+  --db-path /mnt/mainnet/data/db \
+  --output-dir /mnt/mainnet/plinko/regression \
+  --limit 30000000
+```
+
+## Benchmark Results
+
+### Test Parameters
+
+- **Lambda (λ)**: 128
+- **Entries per block (w)**: 49,177
+- **Number of blocks (c)**: 2,440
+- **Number of hints**: 6,294,656
+- **Hint storage**: 192 MB
+
+### Performance (AES-CTR Mode)
+
+| Environment | vCPUs | Time | Throughput | XOR ops/s |
+|-------------|-------|------|------------|-----------|
+| Bare metal | 64 | 57s | 63.8 MB/s | 134M/s |
+| SEV-SNP TEE | 32 | 214s | 17.2 MB/s | 36M/s |
+
+**SEV-SNP overhead**: ~3.7x (with half vCPUs)
+
+### Test Commands
+
+```bash
+# Bare metal
+./target/release/plinko_hints \
+  --db-path regression-data/database.bin \
+  --lambda 128 --aes \
+  --entries-per-block 49177 --allow-truncation
+
+# SEV-SNP (inside VM)
+/mnt/plinko/plinko_hints \
+  --db-path /mnt/plinko/regression.bin \
+  --lambda 128 --aes \
+  --entries-per-block 49177 --allow-truncation
+```
+
+## Test Environment
+
+- **Host**: AMD EPYC 9375F (64 cores, 1.1TB RAM)
+- **SEV-SNP VM**: Ubuntu 24.04, 32 vCPUs, 128GB RAM
+- **QEMU**: 10.0.0 (AMDESE/qemu snp-latest)
+- **OVMF**: edk2-stable202502 (AMDESE/ovmf snp-latest)
+
+## Notes
+
+- This dataset uses the first 30M accounts/storage slots in key order (not recent blocks)
+- The c/w ratio is 0.05, which is suboptimal but sufficient for regression testing
+- For production benchmarks, use the full 73GB mainnet database with w=√N

--- a/regression-data/account-mapping.bin
+++ b/regression-data/account-mapping.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c539b59d6d985bb90a4213510cdd06df82eb64fa4261274ef9772f4912350039
+size 720000000

--- a/regression-data/database.bin.partaa
+++ b/regression-data/database.bin.partaa
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f8eb4864465bf3d08c21ae600f6c65d9c6db6d7bfe0e1787b88b15983f4da91
+size 1992294400

--- a/regression-data/database.bin.partab
+++ b/regression-data/database.bin.partab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93ee2598c76faceda21c7a34040a129f2b95ef66fd297770f072067dbc57cf02
+size 1847705600

--- a/regression-data/metadata.json
+++ b/regression-data/metadata.json
@@ -1,0 +1,7 @@
+{
+  "block": 23889314,
+  "accounts": 30000000,
+  "storage_slots": 30000000,
+  "total_indices": 120000000,
+  "generated_at": "2025-12-05 09:00:12"
+}

--- a/regression-data/storage-mapping.bin
+++ b/regression-data/storage-mapping.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f15d2941e1a7ed8f9777883a645479aa1b7a2736322caefdc829c6cce547db2
+size 1680000000


### PR DESCRIPTION
## Summary

Add a smaller Ethereum state snapshot for fast regression testing and development.

## Dataset

| Metric | Value |
|--------|-------|
| Source Block | #23,889,314 |
| Accounts | 30,000,000 |
| Storage Slots | 30,000,000 |
| Total Entries (N) | 120,000,000 |
| Database Size | 3.6 GB |

## Benchmark Results (lambda=128, w=49177)

| Environment | vCPUs | Time | Throughput | XOR ops/s |
|-------------|-------|------|------------|-----------|
| Bare metal | 64 | 57s | 63.8 MB/s | 134M/s |
| SEV-SNP TEE | 32 | 214s | 17.2 MB/s | 36M/s |

## Files (Git LFS)

- `database.bin.partaa` (1.9 GB) + `database.bin.partab` (1.7 GB) - split for GitHub LFS limit
- `account-mapping.bin` (687 MB)
- `storage-mapping.bin` (1.6 GB)
- `metadata.json`
- `README.md` with usage instructions

Reassemble with: `cat database.bin.part* > database.bin`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Git LFS–tracked regression dataset (split database, mapping files, metadata) with a README covering usage and benchmarks.
> 
> - **Data (Git LFS)**:
>   - Add `regression-data/` binaries: `database.bin.partaa`, `database.bin.partab`, `account-mapping.bin`, `storage-mapping.bin`, and `metadata.json`.
> - **Docs**:
>   - Add `regression-data/README.md` with dataset summary, reassembly instructions (`cat database.bin.part* > database.bin`), extraction command, benchmarks, test commands, environment, and notes.
> - **Repo config**:
>   - Configure `.gitattributes` to track `regression-data/*.bin` and `regression-data/*.part*` via Git LFS.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2f51cf7438362d9e73a3de5c349b1e422096d53. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->