### PR TITLE
docs: add HintInit to Implementation Parity table

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ We maintain consistency between three sources:
 | PMNS inverse | Algorithm 2 | `PMNS.inverse` | `Iprf::trace_ball_inverse` | proptest |
 | Binomial sampling | §4.3: "derandomized using r as randomness" | `binomial_sample` | `Iprf::binomial_sample` | **Kani** |
 | Swap-or-Not PRP | Referenced: Morris-Rogaway 2013 | `SwapOrNot.prp_forward/inverse` | `SwapOrNot::forward/inverse` | proptest |
+| HintInit | Fig. 7: c keys, subset sizes c/2+1 and c/2 | `hint_init`, `process_db_entry` | [plinko_hints.rs](state-syncer/src/bin/plinko_hints.rs) | proptest |
+| Plinko params | §3: w=√N block size | [DbSpec.v](state-syncer/formal/specs/DbSpec.v) | [db.rs](state-syncer/src/db.rs) `derive_plinko_params` | proptest |
 
 **Key design decision**: The paper doesn't specify the exact binomial sampling algorithm. We use a simple integer-arithmetic sampler matching the Coq formalization:
 


### PR DESCRIPTION
Closes #20

Adds rows to the Implementation Parity table in README.md:

| Component | Paper | Coq | Rust | Verified |
|-----------|-------|-----|------|----------|
| HintInit | Fig. 7: c keys, subset sizes c/2+1 and c/2 | `hint_init`, `process_db_entry` | plinko_hints.rs | proptest |
| Plinko params | §3: w=√N block size | DbSpec.v | db.rs `derive_plinko_params` | proptest |

## HintInit (from PR #19)

Key parity points:
- c iPRF keys (one per block)
- Regular hints: c/2+1 block subsets, single parity
- Backup hints: c/2 block subsets, dual parities (in/out)
- iPRF domain=total_hints, range=w

## Plinko params (from #22 review)

- `derive_plinko_params` matches Rocq spec `derive_plinko_params_spec` in DbSpec.v
- Uses integer arithmetic (after PR #24 merges) to match spec exactly
- Proves: power-of-two chunk, sufficient capacity, set_size multiple of 4