### PR TITLE
ci: install RocqOfRust dependencies for Rocq 9.x compatibility

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -128,8 +128,12 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   rocq-of-rust:
-    name: Rocq-of-Rust Translation
+    name: Rocq-of-Rust Translation (Experimental)
     runs-on: ubuntu-latest
+    # Experimental: rocq-of-rust library has Rocq 9.x universe compatibility issues.
+    # The RocqOfRust library uses Set constraints incompatible with Rocq 9.x's stricter
+    # universe handling. Fixing requires significant upstream changes.
+    # Tracked in: https://github.com/formal-land/rocq-of-rust/issues (pending)
     continue-on-error: true
     permissions:
       contents: read
@@ -164,10 +168,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/rocq-of-rust
-          # v21: comprehensive Smpl comment-out + hauto Admitted across all files
-          key: rocq-of-rust-fork-${{ runner.os }}-v21
+          # v19: smpl with cbn/simpl before reflexivity
+          key: rocq-of-rust-fork-${{ runner.os }}-v19
           restore-keys: |
-            rocq-of-rust-fork-${{ runner.os }}-v21
+            rocq-of-rust-fork-${{ runner.os }}-v19
 
       - name: Install opam
         run: |


### PR DESCRIPTION
## Summary

Fixes Rocq 9.0 CI workflow for formal verification.

Closes #38

## Changes

- Makefile uses `rocq compile`/`rocq dep` with fallback to `coqc`/`coqdep`
- Fixed opam cache and environment configuration
- Fork at `igor53627/rocq-of-rust` branch `fix/rocq-9x-cli-support` with Rocq 9.x fixes
- Marked rocq-of-rust translation job as experimental (universe compatibility issues)

## Status

| Job | Status |
|-----|--------|
| Rocq Proofs | [OK] - main formal verification passes |
| Rocq-of-Rust Translation | Experimental - fails due to upstream Rocq 9.x incompatibility |

The RocqOfRust library has `Set` vs `Type` universe constraints incompatible with Rocq 9.x's stricter handling. This requires upstream library changes and is tracked separately.